### PR TITLE
Fixed potential aspect ratio bug

### DIFF
--- a/NotEnoughAV1Encodes/Video/VideoDB.cs
+++ b/NotEnoughAV1Encodes/Video/VideoDB.cs
@@ -42,7 +42,7 @@ namespace NotEnoughAV1Encodes.Video
                 try { MIIsVFR = mediaInfo.Get(StreamKind.Video, 0, "FrameRate_Mode") == "VFR"; } catch { MIIsVFR = false; }
                 try { MIWidth = int.Parse(mediaInfo.Get(StreamKind.Video, 0, "Width")); } catch { }
                 try { MIHeight = int.Parse(mediaInfo.Get(StreamKind.Video, 0, "Height")); } catch { }
-                try { MIDisplayAspectRatio = mediaInfo.Get(StreamKind.Video, 0, "DisplayAspectRatio/String").Replace(":1", ""); } catch { }
+                try { MIDisplayAspectRatio = mediaInfo.Get(StreamKind.Video, 0, "DisplayAspectRatio"); if (MIDisplayAspectRatio.EndsWith(":1")) { MIDisplayAspectRatio = MIDisplayAspectRatio.Replace(":1", ""); }; } catch { }
                 try { MIPixelAspectRatio = mediaInfo.Get(StreamKind.Video, 0, "PixelAspectRatio"); } catch { }
 
                 int audioCount = mediaInfo.Count_Get(StreamKind.Audio);

--- a/NotEnoughAV1Encodes/Video/VideoDB.cs
+++ b/NotEnoughAV1Encodes/Video/VideoDB.cs
@@ -42,7 +42,7 @@ namespace NotEnoughAV1Encodes.Video
                 try { MIIsVFR = mediaInfo.Get(StreamKind.Video, 0, "FrameRate_Mode") == "VFR"; } catch { MIIsVFR = false; }
                 try { MIWidth = int.Parse(mediaInfo.Get(StreamKind.Video, 0, "Width")); } catch { }
                 try { MIHeight = int.Parse(mediaInfo.Get(StreamKind.Video, 0, "Height")); } catch { }
-                try { MIDisplayAspectRatio = mediaInfo.Get(StreamKind.Video, 0, "DisplayAspectRatio"); if (MIDisplayAspectRatio.EndsWith(":1")) { MIDisplayAspectRatio = MIDisplayAspectRatio.Replace(":1", ""); }; } catch { }
+                try { MIDisplayAspectRatio = mediaInfo.Get(StreamKind.Video, 0, "DisplayAspectRatio/String"); if (MIDisplayAspectRatio.EndsWith(":1")) { MIDisplayAspectRatio = MIDisplayAspectRatio.Replace(":1", ""); }; } catch { }
                 try { MIPixelAspectRatio = mediaInfo.Get(StreamKind.Video, 0, "PixelAspectRatio"); } catch { }
 
                 int audioCount = mediaInfo.Count_Get(StreamKind.Audio);

--- a/NotEnoughAV1Encodes/Video/VideoDB.cs
+++ b/NotEnoughAV1Encodes/Video/VideoDB.cs
@@ -42,7 +42,7 @@ namespace NotEnoughAV1Encodes.Video
                 try { MIIsVFR = mediaInfo.Get(StreamKind.Video, 0, "FrameRate_Mode") == "VFR"; } catch { MIIsVFR = false; }
                 try { MIWidth = int.Parse(mediaInfo.Get(StreamKind.Video, 0, "Width")); } catch { }
                 try { MIHeight = int.Parse(mediaInfo.Get(StreamKind.Video, 0, "Height")); } catch { }
-                try { MIDisplayAspectRatio = mediaInfo.Get(StreamKind.Video, 0, "DisplayAspectRatio/String"); if (MIDisplayAspectRatio.EndsWith(":1")) { MIDisplayAspectRatio = MIDisplayAspectRatio.Replace(":1", ""); }; } catch { }
+                try { MIDisplayAspectRatio = mediaInfo.Get(StreamKind.Video, 0, "DisplayAspectRatio/String"); if (MIDisplayAspectRatio.EndsWith(":1") && MIDisplayAspectRatio != "3:1" && MIDisplayAspectRatio != "1:1") { MIDisplayAspectRatio = MIDisplayAspectRatio.Replace(":1", ""); }; } catch { }
                 try { MIPixelAspectRatio = mediaInfo.Get(StreamKind.Video, 0, "PixelAspectRatio"); } catch { }
 
                 int audioCount = mediaInfo.Count_Get(StreamKind.Audio);

--- a/NotEnoughAV1Encodes/Video/VideoDB.cs
+++ b/NotEnoughAV1Encodes/Video/VideoDB.cs
@@ -42,7 +42,7 @@ namespace NotEnoughAV1Encodes.Video
                 try { MIIsVFR = mediaInfo.Get(StreamKind.Video, 0, "FrameRate_Mode") == "VFR"; } catch { MIIsVFR = false; }
                 try { MIWidth = int.Parse(mediaInfo.Get(StreamKind.Video, 0, "Width")); } catch { }
                 try { MIHeight = int.Parse(mediaInfo.Get(StreamKind.Video, 0, "Height")); } catch { }
-                try { MIDisplayAspectRatio = mediaInfo.Get(StreamKind.Video, 0, "DisplayAspectRatio/String"); } catch { }
+                try { MIDisplayAspectRatio = mediaInfo.Get(StreamKind.Video, 0, "DisplayAspectRatio/String").Replace(":1", ""); } catch { }
                 try { MIPixelAspectRatio = mediaInfo.Get(StreamKind.Video, 0, "PixelAspectRatio"); } catch { }
 
                 int audioCount = mediaInfo.Count_Get(StreamKind.Audio);


### PR DESCRIPTION
I had a problem with encoding one of my videos earlier with NEAV1E and found out that there was a bug with getting the aspect ratio variable.

On a couple of videos I've been trying to encode the aspect ratio was identified as "2.4.0:1" and when it's eventually passed to ffmpeg for muxing, NEAV1E errors out with the following:
![Screenshot 2022-12-22 004322](https://user-images.githubusercontent.com/16258926/209030464-8b055199-b952-44e0-994a-a711b8a7e478.jpg)

I put the same ffmpeg arguments used by the program in a terminal and shows the following error:
```
.\ffmpeg.exe -y -f concat -safe 0 -i "F:\Temp\NEAV1E\xZuAnqUnDqWFpNe\chunks.txt" -aspect 2.40:1 -c copy "F:\Temp\NEAV1E\xZuAnqUnDqWFpNe\temp_mux.mkv"
ffmpeg version N-109422-g52311b87ef-g262e7439c6+2 Copyright (c) 2000-2022 the FFmpeg developers
  built with gcc 12.2.0 (Rev6, Built by MSYS2 project)
  configuration:  --pkg-config=pkgconf --cc='ccache gcc' --cxx='ccache g++' --ld='ccache g++' --extra-cxxflags=-fpermissive --extra-cflags=-Wno-int-conversion --enable-amf --enable-bzlib --enable-cuda --enable-cuvid --enable-d3d11va --enable-dxva2 --enable-iconv --enable-lzma --enable-nvenc --enable-zlib --enable-sdl2 --enable-ffnvcodec --enable-nvdec --enable-cuda-llvm --enable-gmp --enable-libmp3lame --enable-libopus --enable-libvorbis --enable-libvpx --enable-libx264 --enable-libx265 --enable-libdav1d --disable-debug --enable-fontconfig --enable-libass --enable-libbluray --enable-libfreetype --enable-libmfx --enable-libmysofa --enable-libopencore-amrnb --enable-libopencore-amrwb --enable-libopenjpeg --enable-libsnappy --enable-libsoxr --enable-libspeex --enable-libtheora --enable-libtwolame --enable-libvidstab --enable-libvo-amrwbenc --enable-libwebp --enable-libzimg --enable-gpl --enable-avisynth --enable-libxvid --enable-libaom --enable-libopenmpt --enable-version3 --enable-libcaca --enable-libflite --enable-libfribidi --enable-libilbc --enable-libsvtav1 --enable-libmodplug --enable-librubberband --enable-libxavs --enable-libzmq --enable-libzvbi --enable-openal --enable-libvmaf --enable-libcodec2 --enable-libsrt --enable-vapoursynth --enable-librav1e --enable-libjxl --enable-libplacebo --enable-opencl --enable-opengl --enable-gnutls --extra-cflags=-DLIBTWOLAME_STATIC --extra-libs=-lstdc++ --extra-cflags=-DCACA_STATIC --extra-cflags=-DMODPLUG_STATIC --extra-cflags=-DZMQ_STATIC --disable-w32threads --extra-cflags=-DAL_LIBTYPE_STATIC --extra-cflags='-IC:/media-autobuild_suite/local64/include' --extra-cflags='-IC:/media-autobuild_suite/local64/include/AL'
  libavutil      57. 43.100 / 57. 43.100
  libavcodec     59. 55.100 / 59. 55.100
  libavformat    59. 34.102 / 59. 34.102
  libavdevice    59.  8.101 / 59.  8.101
  libavfilter     8. 52.100 /  8. 52.100
  libswscale      6.  8.112 /  6.  8.112
  libswresample   4.  9.100 /  4.  9.100
  libpostproc    56.  7.100 / 56.  7.100
[libdav1d @ 0000028f3ef89ac0] libdav1d 1.0.0-105-ged63a74
[libdav1d @ 0000028f3ef8f500] libdav1d 1.0.0-105-ged63a74
Input #0, concat, from 'F:\Temp\NEAV1E\xZuAnqUnDqWFpNe\chunks.txt':
  Duration: N/A, start: 0.000000, bitrate: N/A
  Stream #0:0: Video: av1 (Main) (AV01 / 0x31305641), yuv420p(tv), 708x424 [SAR 1:1 DAR 177:106], 25 tbr, 25 tbn
[Eval @ 000000ef183fec00] Invalid chars ':1' at the end of expression '2.40:1'
Invalid aspect ratio: 2.40:1
```

The fix I originally thought of was to replace the "DisplayAspectRatio/String" with "DisplayAspectRatio" but that caused some differences ("2.4.0:1" -> "2.375"). A better way I found was to just remove the ":1" but that would cause problems with 16:10 so adding a check for the last 2 characters to be ":1" and for the 3:1 and 1:1 ratios was a good fit.

After changing the code I was able to successfully encode the video.

Additional Info: The ffmpeg used was the one found in "Apps/FFmpeg" and not the one installed on system. [Here's the NEAV1E log file](https://github.com/Alkl58/NotEnoughAV1Encodes/files/10282837/SomeVideoEncoded.mkv.log)
